### PR TITLE
Wrap everything in a javascript closure to prevent scope leakage

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,10 +4,12 @@
  *                              *
  ********************************/
 
+(function(){
+
 /**
  * Helpers
  */
-$ = {};
+var $ = {};
 
 $.id = function(id) {
   return document.getElementById(id);
@@ -4205,3 +4207,5 @@ div.post-hidden:not(#quote-preview) blockquote.postMessage {\
 };
 
 Main.init();
+
+})();


### PR DESCRIPTION
This frees up `$` for other scripts (like jQuery) while still allowing 4chan-JS to use it the same way.
